### PR TITLE
Setup connection to AWS database server

### DIFF
--- a/deploy/manifests/base/config.yaml
+++ b/deploy/manifests/base/config.yaml
@@ -16,3 +16,4 @@ default-miner-config:
     retrieval-timeout: 1m0s
     max-concurrent-retrievals: 1
 miner-configs: {}
+event-recorder-endpoint-url: https://vtz1qw149h.execute-api.us-east-2.amazonaws.com

--- a/deploy/manifests/base/deployment.yaml
+++ b/deploy/manifests/base/deployment.yaml
@@ -38,6 +38,9 @@ spec:
             - name: identity
               mountPath: /data/.autoretrieve/peerkey
               subPath: peerkey
+            - name: authorization
+              mountPath: /data/.autoretrieve/eventrecorderauth
+              subPath: eventrecorderauth
           resources:
             limits:
               memory: 32Gi
@@ -53,3 +56,9 @@ spec:
             items:
               - key: peerkey.encrypted
                 path: ./peerkey
+        - name: authorization
+          secret:
+            secretName: autoretrieve-authorization
+            items:
+              - key: eventrecorderauth.encrypted
+                path: ./eventrecorderauth

--- a/deploy/manifests/base/eventrecorderauth.encrypted
+++ b/deploy/manifests/base/eventrecorderauth.encrypted
@@ -1,0 +1,2 @@
+This is a placeholder file that should contain the encrypted http authorization keys to publish
+to the database server of the autoretrieve host.

--- a/deploy/manifests/base/kustomization.yaml
+++ b/deploy/manifests/base/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
 configMapGenerator:
   - name: autoretrieve-config
     files:
-      - config.yaml.erb
+      - config.yaml
   - name: autoretrieve-env
     literals:
       - FULLNODE_API_INFO=wss://api.chain.love

--- a/deploy/manifests/base/kustomization.yaml
+++ b/deploy/manifests/base/kustomization.yaml
@@ -10,7 +10,7 @@ resources:
 configMapGenerator:
   - name: autoretrieve-config
     files:
-      - config.yaml
+      - config.yaml.erb
   - name: autoretrieve-env
     literals:
       - FULLNODE_API_INFO=wss://api.chain.love
@@ -19,3 +19,8 @@ secretGenerator:
   - name: autoretrieve-identity
     files:
       - peerkey.encrypted
+
+secretGenerator:
+  - name: autoretrieve-authorization
+    files:
+      - eventrecorderauth.encrypted

--- a/deploy/manifests/dev/us-east-2/config.yaml
+++ b/deploy/manifests/dev/us-east-2/config.yaml
@@ -16,3 +16,4 @@ default-miner-config:
     retrieval-timeout: 1m0s
     max-concurrent-retrievals: 1
 miner-configs: {}
+event-recorder-endpoint-url: https://vtz1qw149h.execute-api.us-east-2.amazonaws.com

--- a/deploy/manifests/dev/us-east-2/eventrecorderauth.encrypted
+++ b/deploy/manifests/dev/us-east-2/eventrecorderauth.encrypted
@@ -1,0 +1,22 @@
+{
+	"data": "ENC[AES256_GCM,data:nOJ5ZiJuXtWePK13Un681URQAT5w/7RfN8aPz23jjXaS0v/jnY+hPtNgVUy/w692Yp/q,iv:yQyH3A3qGsgrG1ImT53weitiQ909QZVGyOowi6vPy00=,tag:Mo9wTXIHJ7WnlXU4IRuK6w==,type:str]",
+	"sops": {
+		"kms": [
+			{
+				"arn": "arn:aws:kms:us-east-2:407967248065:alias/dev/us-east-2/autoretrieve",
+				"created_at": "2022-07-31T04:10:14Z",
+				"enc": "AQICAHgZ4zxFMLYL2iEHWJJh7edGwSAfx3nqUsNmImHieESc3QGnhGEEOqHoOesXGYJRH6ZAAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/kKHz/IKc+6tE6bWAgEQgDsjVVnLma/IX2lYhsKUu0ogA+3//zKsJBWaY1I/uUmbqeKX1TuUV7apdabna0W1PEjKdq4Qo6OHw8BArg==",
+				"aws_profile": ""
+			}
+		],
+		"gcp_kms": null,
+		"azure_kv": null,
+		"hc_vault": null,
+		"age": null,
+		"lastmodified": "2022-07-31T04:10:15Z",
+		"mac": "ENC[AES256_GCM,data:VzJ5Y2q0dfmttVSttcRaMyBWkAROMDOkSHrn6KXudNtvE4cnYyS37ZSGq+H6zPWbbVjC6FV5TUZjLfIwHcFAg+mdsqhWaf2US7FV29UjxX31y62lVB5o5PoB9xzAwcMlPgJWyB3tRaCSo091cHsSyrBEHDZlzH8p+f1Y/Gzec6c=,iv:YqkTbfNgbeA4LH54lSayDkeWwt78chufaJmIlycp6Fg=,tag:GEKDQlgh1trZD8Rn+/SLFg==,type:str]",
+		"pgp": null,
+		"unencrypted_suffix": "_unencrypted",
+		"version": "3.7.3"
+	}
+}

--- a/deploy/manifests/dev/us-east-2/eventrecorderauth.encrypted
+++ b/deploy/manifests/dev/us-east-2/eventrecorderauth.encrypted
@@ -1,11 +1,11 @@
 {
-	"data": "ENC[AES256_GCM,data:nOJ5ZiJuXtWePK13Un681URQAT5w/7RfN8aPz23jjXaS0v/jnY+hPtNgVUy/w692Yp/q,iv:yQyH3A3qGsgrG1ImT53weitiQ909QZVGyOowi6vPy00=,tag:Mo9wTXIHJ7WnlXU4IRuK6w==,type:str]",
+	"data": "ENC[AES256_GCM,data:DVlWNviyk8YOXeiUzXkANVWunSiK4Q5O4WXW5X++Xzw+2a10ZpeESeRDVAfE,iv:2dZcILVj7VWBPFzrUXCH1Bji85VigFj/pQid2xk6Voo=,tag:LiLhFSOnBCmSCJ9dQduSpA==,type:str]",
 	"sops": {
 		"kms": [
 			{
 				"arn": "arn:aws:kms:us-east-2:407967248065:alias/dev/us-east-2/autoretrieve",
-				"created_at": "2022-07-31T04:10:14Z",
-				"enc": "AQICAHgZ4zxFMLYL2iEHWJJh7edGwSAfx3nqUsNmImHieESc3QGnhGEEOqHoOesXGYJRH6ZAAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM/kKHz/IKc+6tE6bWAgEQgDsjVVnLma/IX2lYhsKUu0ogA+3//zKsJBWaY1I/uUmbqeKX1TuUV7apdabna0W1PEjKdq4Qo6OHw8BArg==",
+				"created_at": "2022-08-04T21:16:08Z",
+				"enc": "AQICAHgZ4zxFMLYL2iEHWJJh7edGwSAfx3nqUsNmImHieESc3QH6oWOROnk3MODleClrNAzUAAAAfjB8BgkqhkiG9w0BBwagbzBtAgEAMGgGCSqGSIb3DQEHATAeBglghkgBZQMEAS4wEQQM42G7r4mSSy21djbPAgEQgDvO4UzFVArOV9PypyYC8jqnMAeKAg52elf7OGgk91EWV0yzNZkGY4ldldmJYWjMDrbv+kIKaGK2VwNdKA==",
 				"aws_profile": ""
 			}
 		],
@@ -13,8 +13,8 @@
 		"azure_kv": null,
 		"hc_vault": null,
 		"age": null,
-		"lastmodified": "2022-07-31T04:10:15Z",
-		"mac": "ENC[AES256_GCM,data:VzJ5Y2q0dfmttVSttcRaMyBWkAROMDOkSHrn6KXudNtvE4cnYyS37ZSGq+H6zPWbbVjC6FV5TUZjLfIwHcFAg+mdsqhWaf2US7FV29UjxX31y62lVB5o5PoB9xzAwcMlPgJWyB3tRaCSo091cHsSyrBEHDZlzH8p+f1Y/Gzec6c=,iv:YqkTbfNgbeA4LH54lSayDkeWwt78chufaJmIlycp6Fg=,tag:GEKDQlgh1trZD8Rn+/SLFg==,type:str]",
+		"lastmodified": "2022-08-04T21:16:09Z",
+		"mac": "ENC[AES256_GCM,data:vV9t6nW6Q5ON5S7wfQSU6CXM63KfOSiTynmAPZSMQ6tghE0FGcgmsAxX/pGGvfBYYXohS4+bMVSpCOifaG2R3484jWDOL6OHUh3Ah7sU5dt/FfdL1PizRuXMh49PPR+4pNA94/NZfv+QhKknsqOhzrcybTQc7E5nNkshBVKjM6g=,iv:N8mvgJXb+/1WVyd8KIrgWh2drWp3lbwSQ4VFtpDkDto=,tag:JWfJ0/mhauWeQFeG/ayrwQ==,type:str]",
 		"pgp": null,
 		"unencrypted_suffix": "_unencrypted",
 		"version": "3.7.3"

--- a/deploy/manifests/dev/us-east-2/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/kustomization.yaml
@@ -16,6 +16,11 @@ secretGenerator:
   behavior: replace
   files:
   - peerkey.encrypted
+secretGenerator:
+- name: autoretrieve-authorization
+  behavior: replace
+  files:
+  - eventrecorderauth.encrypted
 images:
 - name: autoretrieve
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/autoretrieve/autoretrieve # {"$imagepolicy": "autoretrieve:autoretrieve:name"}

--- a/deploy/manifests/dev/us-east-2/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/kustomization.yaml
@@ -11,16 +11,21 @@ patchesStrategicMerge:
 replicas:
 - name: autoretrieve
   count: 1
+configMapGenerator:
+  - name: autoretrieve-config
+    behavior: replace
+    files:
+      - config.yaml
 secretGenerator:
-- name: autoretrieve-identity
-  behavior: replace
-  files:
-  - peerkey.encrypted
+  - name: autoretrieve-identity
+    behavior: replace
+    files:
+    - peerkey.encrypted
 secretGenerator:
-- name: autoretrieve-authorization
-  behavior: replace
-  files:
-  - eventrecorderauth.encrypted
+  - name: autoretrieve-authorization
+    behavior: replace
+    files:
+    - eventrecorderauth.encrypted
 images:
 - name: autoretrieve
   newName: 407967248065.dkr.ecr.us-east-2.amazonaws.com/autoretrieve/autoretrieve # {"$imagepolicy": "autoretrieve:autoretrieve:name"}


### PR DESCRIPTION
# Goals

Connect autoretrieve deployment to AWS database server

# Implementation

- add value for event_recorder_endpoint_url in config.yaml. Currently, this just points to current value for the AWS api server. Probably that server should get an alternate DNS name that stays static and we should use that so we don't have to update.
- add a secret and configs to manage the secret for the Basic auth header we need to pass through to the AWS server so our requests will write.
    - the secret is in an encrypted file encrypted per https://github.com/filecoin-project/storetheindex/tree/main/deploy/manifests#secret-management
    - the unencrypted text of the file is simply `Basic ~base64 encode of current Autoretrieve API Secret in AWS~`
    - the specific command I used to encrypt was `sops --input-type binary -i -e eventrecorderauth.encrypted`
- the current setup is non ideal cause every time the secret is updated in secrets manager, it will need to be updated as well here. I've already reached out to @masih about having us directly import AWS secrets from secrets manager per https://docs.aws.amazon.com/secretsmanager/latest/userguide/integrating_csi_driver.html  . But that's a separate process.

All that being said, I think all the parts are here to work until the config changes again for the autoretrieve database server.

Requires https://github.com/application-research/autoretrieve/pull/107 as well to have any effect