### PR TITLE
fix: separate infrastructure into multiple stacks

### DIFF
--- a/retrieval-api/app/retrieval-events-app.ts
+++ b/retrieval-api/app/retrieval-events-app.ts
@@ -1,14 +1,12 @@
 #!/usr/bin/env node
 import 'source-map-support/register';
 import { App } from 'aws-cdk-lib';
-import { RetrievalEventsStack } from "../src/retrieval-api-stack";
+import { ApiStack } from "../src/infra/stacks/api-stack";
+import { DatabaseStack } from "../src/infra/stacks/database-stack";
+import { ServerStack } from "../src/infra/stacks/server-stack";
 
 const ACCOUNT_ID = '407967248065';
-
-const app = new App();
-new RetrievalEventsStack(app, 'AutoretrieveRetrievalEventsStack', {
-  stackName: 'AutoretrieveRetrievalEventsStack',
-  description: 'Autoretrieve Retrieval Events',
+const STACK_PROPS = {
   env: {
     account: ACCOUNT_ID,
     region: 'us-east-2'
@@ -16,4 +14,30 @@ new RetrievalEventsStack(app, 'AutoretrieveRetrievalEventsStack', {
   tags: {
     app: "autoretrieve"
   }
+};
+
+const app = new App();
+const databaseStack = new DatabaseStack(app, 'AutoretrieveRetrievalEventsStack', {
+  stackName: 'AutoretrieveRetrievalEventsStack',
+  description: 'Autoretrieve Retrieval Events | VPC and Database',
+  ...STACK_PROPS
+});
+
+new ServerStack(app, "ServerStack", {
+  stackName: "AutoretrieveRetreivalEventsServerStack",
+  description: "Autoretrieve Retrieval Events | EC2 pgAdmin Server",
+  database: databaseStack.database,
+  databaseSecurityGroup: databaseStack.securityGroup,
+  vpc: databaseStack.vpc,
+  ...STACK_PROPS
+});
+
+new ApiStack(app, "ApiStack", {
+  stackName: "AutoretrieveRetrievalEventsApiStack",
+  description: "Autoretrieve Retrieval Events | API and Lambdas",
+  database: databaseStack.database,
+  databaseSecurityGroup: databaseStack.securityGroup,
+  databaseUsername: databaseStack.databaseUsername,
+  vpc: databaseStack.vpc,
+  ...STACK_PROPS
 });

--- a/retrieval-api/cdk.context.json
+++ b/retrieval-api/cdk.context.json
@@ -9,5 +9,9 @@
     "us-east-2a",
     "us-east-2b",
     "us-east-2c"
-  ]
+  ],
+  "hosted-zone:account=407967248065:domainName=dev.cid.contact:region=us-east-2": {
+    "Id": "/hostedzone/Z0346653G546POP574CS",
+    "Name": "dev.cid.contact."
+  }
 }

--- a/retrieval-api/src/infra/stacks/api-stack.ts
+++ b/retrieval-api/src/infra/stacks/api-stack.ts
@@ -1,0 +1,168 @@
+import { Duration, Stack, StackProps } from "aws-cdk-lib";
+import { LambdaIntegration, RequestAuthorizer, RestApi } from "aws-cdk-lib/aws-apigateway";
+import { Port, SecurityGroup, SubnetType, Vpc } from "aws-cdk-lib/aws-ec2";
+import { Grant, IPrincipal } from "aws-cdk-lib/aws-iam";
+import { Alias, Code, Function, Runtime, Version } from "aws-cdk-lib/aws-lambda";
+import { DatabaseInstance } from "aws-cdk-lib/aws-rds";
+import { Secret } from "aws-cdk-lib/aws-secretsmanager";
+import { AwsCustomResource, AwsCustomResourcePolicy, PhysicalResourceId } from "aws-cdk-lib/custom-resources";
+import { Construct } from "constructs";
+
+export interface ApiStackProps extends StackProps {
+  database: DatabaseInstance
+  databaseSecurityGroup: SecurityGroup
+  databaseUsername: string
+  vpc: Vpc
+}
+
+export class ApiStack extends Stack {
+  readonly api: RestApi;
+  readonly securityGroup: SecurityGroup;
+
+  constructor(scope: Construct, id: string, props: ApiStackProps) {
+    super(scope, id, props);
+
+    const prefix = Stack.of(this).stackName;
+
+    // API root
+    const api = new RestApi(this, "RestApi", {
+      restApiName: `${prefix}-RestApi`
+    });
+
+    // Setup the API resource for POSTing retrieval events
+    const v1 = api.root.addResource("v1");
+    const v1RetrievalEvents = v1.addResource("retrieval-events");
+
+    // Generate secret string for API Key
+    const apiKeySecret = new Secret(this, "ApiKeySecret", {
+      secretName: `${prefix}-ApiKeySecret`,
+      description: "The API key for authorizing with the Autoretrieve Retrieval Events API.",
+      generateSecretString: {
+        excludePunctuation: true
+      }
+    });
+
+    // Function for basic authorization
+    const basicAuthFn = new Function(this, "BasicAuthLambdaAuthorizerFunction", {
+      functionName: `${prefix}-BasicAuthLambdaAuthorizer`,
+      code: Code.fromAsset("dist/lambdas/BasicAuthLambdaAuthorizer"),
+      handler: "index.BasicAuthLambdaAuthorizer",
+      runtime: Runtime.NODEJS_16_X,
+      environment: {
+        API_ENDPOINT_ARN: `arn:aws:execute-api:${this.region}:${this.account}:${api.restApiId}/*/POST/retrieval-events`,
+        API_KEY_SECRET_ARN: apiKeySecret.secretFullArn!
+      },
+      memorySize: 1024,
+      timeout: Duration.seconds(5),
+      vpc: props.vpc,
+      vpcSubnets: {
+        subnetType: SubnetType.PRIVATE_ISOLATED
+      }
+    });
+    // Allow the basic auth function to read the secret
+    apiKeySecret.grantRead(basicAuthFn);
+
+    // The basic auth authorizer
+    const basicAuthAuthorizer = new RequestAuthorizer(this, "BasicAuthAuthorizer", {
+      authorizerName: `${prefix}-BasicAuthAuthorizer`,
+      handler: basicAuthFn,
+      identitySources: [],
+      resultsCacheTtl: Duration.minutes(0)
+    });
+
+    this.securityGroup = new SecurityGroup(this, "LambdaDatabaseProxy", {
+      vpc: props.vpc
+    });
+    props.databaseSecurityGroup.addIngressRule(this.securityGroup, Port.tcp(5432), "Allow access from lambdas", true);
+
+    // Function for saving retrieval events
+    const saveRetrievalEventFn = new Function(this, "SaveRetrievalEventFunction", {
+      functionName: `${prefix}-SaveRetrievalEventLambda`,
+      code: Code.fromAsset("dist/lambdas/SaveRetrievalEventLambda"),
+      handler: "index.SaveRetrievalEventLambda",
+      runtime: Runtime.NODEJS_16_X,
+      environment: {
+        DB_HOST: props.database.secret?.secretValueFromJson("host").toString()!,
+        DB_PORT: props.database.secret?.secretValueFromJson("port").toString()!,
+        // Passing the password via environment variable is not ideal, but it allows us to use connection pools effeciently
+        DB_PASSWORD: props.database.secret?.secretValueFromJson("password").toString()!,
+        DB_USERNAME: props.databaseUsername,
+        DB_NAME: props.database.secret?.secretValueFromJson("dbname").toString()!
+      },
+      memorySize: 1024,
+      timeout: Duration.seconds(5),
+      vpc: props.vpc,
+      vpcSubnets: {
+        subnetType: SubnetType.PRIVATE_ISOLATED
+      },
+      securityGroups: [this.securityGroup]
+    });
+    // Give the function network access to the database
+    // props.database.connections.allowFrom(saveRetrievalEventFn, Port.tcp(5432));
+    // Give the function permission to access the database and database credentials
+    grantConnect(this, props.database, props.databaseUsername, saveRetrievalEventFn.role?.grantPrincipal!);
+    props.database.secret?.grantRead(saveRetrievalEventFn);
+    
+    // Setup v1 of retrieval-events lambda
+    const saveRetrievalEventFnV1 = new Version(this, "SaveRetrievalEventFunctionV1", {
+      lambda: saveRetrievalEventFn
+    });
+    const saveRetrievalEventFnV1Alias = new Alias(this, "SaveRetrievalEventFunctionV1Alias", {
+      aliasName: "SaveRetreivalEventFunctionV1",
+      version: saveRetrievalEventFnV1
+    });
+  
+    // The POST method for saving retrieval events
+    v1RetrievalEvents.addMethod("POST", new LambdaIntegration(saveRetrievalEventFnV1Alias), {
+      authorizer: basicAuthAuthorizer
+    });
+  }
+}
+
+// Custom grantConnect function due to a bug in AWS where an RDS instance's resource ID is not available from Cloudformation.
+// More information here: https://github.com/aws/aws-cdk/issues/11851
+function grantConnect(scope: Stack, db: DatabaseInstance, dbUsername: string, grantPrincipal: IPrincipal) {
+  // This could be undefined in some cases, just no op.
+  if(grantPrincipal === undefined){
+    console.warn(`Could not grant connect to RDS instance ${db.instanceIdentifier} because grant principle is undefined.`); 
+    return;
+  }
+
+  // Custom resource for retrieving the DB Resource ID from an RDS instance using an SDK call
+  const dbResourceId = new AwsCustomResource(
+    scope,
+    `RdsResourceId-${grantPrincipal}`,
+    {
+      onUpdate: {
+        service: "RDS",
+        action: "describeDBInstances",
+        parameters: {
+          DBInstanceIdentifier: db.instanceIdentifier,
+        },
+        physicalResourceId: PhysicalResourceId.fromResponse(
+          "DBInstances.0.DbiResourceId"
+        ),
+        outputPaths: ["DBInstances.0.DbiResourceId"],
+      },
+      policy: AwsCustomResourcePolicy.fromSdkCalls({
+        resources: AwsCustomResourcePolicy.ANY_RESOURCE,
+      }),
+    }
+  );
+  const resourceId = dbResourceId.getResponseField(
+    "DBInstances.0.DbiResourceId"
+  );
+
+  // Ensure this custom resource waits for the DB instance lifecycle to complete before executing it's own lifecycle
+  dbResourceId.node.addDependency(db);
+
+  // This is the correct ARN structure needed
+  const dbUserArn = `arn:aws:rds-db:${scope.region}:${scope.account}:dbuser:${resourceId}/${dbUsername}`;
+
+  // Add the rds-db:connect action and correct DB instance ARN to the grant principle
+  Grant.addToPrincipal({
+    grantee: grantPrincipal,
+    actions: ['rds-db:connect'],
+    resourceArns: [dbUserArn],
+  });
+}

--- a/retrieval-api/src/infra/stacks/server-stack.ts
+++ b/retrieval-api/src/infra/stacks/server-stack.ts
@@ -1,0 +1,68 @@
+import { Stack, StackProps } from "aws-cdk-lib";
+import {
+  AmazonLinuxGeneration, AmazonLinuxImage, CfnEIP, CfnKeyPair, Instance,
+  InstanceClass, InstanceSize, InstanceType, Port,
+  SecurityGroup, SubnetType, Vpc
+} from "aws-cdk-lib/aws-ec2";
+import { DatabaseInstance } from "aws-cdk-lib/aws-rds";
+import { ARecord, HostedZone, RecordTarget } from "aws-cdk-lib/aws-route53";
+import { Construct } from "constructs";
+
+export interface ServerStackProps extends StackProps {
+  database: DatabaseInstance
+  databaseSecurityGroup: SecurityGroup
+  vpc: Vpc
+}
+
+export class ServerStack extends Stack {
+  readonly aRecord: ARecord;
+  readonly ec2: Instance;
+  readonly elasticIp: CfnEIP;
+  readonly securityGroup: SecurityGroup;
+  
+  constructor(scope: Construct, id: string, props: ServerStackProps) {
+    super(scope, id, props);
+    
+    this.securityGroup = new SecurityGroup(this, "Ec2DatabaseProxy", {
+      vpc: props.vpc
+    });
+    props.databaseSecurityGroup.addIngressRule(this.securityGroup, Port.tcp(54342), "Allow connection from ec2 server", true);
+
+    new CfnKeyPair(this, "Ec2KeyPair", { keyName: "autoretrieve-retrieval-events-server-key-pair" });
+    this.ec2 = new Instance(this, "PGAdminInstance", {
+      vpc: props.vpc,
+      vpcSubnets: {
+        subnetType: SubnetType.PUBLIC
+      },
+      machineImage: new AmazonLinuxImage({
+        generation: AmazonLinuxGeneration.AMAZON_LINUX_2
+      }),
+      instanceName: "autoretrieve-retrieval-events-pgadmin-instance",
+      instanceType: InstanceType.of(InstanceClass.T2, InstanceSize.LARGE),
+      securityGroup: this.securityGroup,
+      keyName: "autoretrieve-retrieval-events-server-key-pair"
+    });
+
+    // Allow SSH connection from anywhere
+    this.ec2.connections.allowFromAnyIpv4(Port.tcp(22));
+    // Allow database connection from pgAdmin to the database
+
+    // props.database.connections.allowFrom(this.ec2, Port.tcp(5432));
+
+    // Give the EC2 instance an elastic IP so that we can point our domain at it
+    this.elasticIp = new CfnEIP(this, "Ec2ElasticIP", {
+      instanceId: this.ec2.instanceId
+    });
+
+    // Reference the parent hosted zone
+    const parentZone = HostedZone.fromLookup(this, "DevCidContactZone", {
+      domainName: "dev.cid.contact" 
+    });
+    // Point domain at elastic IP
+    this.aRecord = new ARecord(this, "ARecordEc2", {
+      recordName: "pgadmin.autoretrieve.dev.cid.contact",
+      target: RecordTarget.fromIpAddresses(this.elasticIp.ref),
+      zone: parentZone
+    });
+  }
+}


### PR DESCRIPTION
So this separates the EC2 instance, API and lambdas, and VPC and Database into different stacks. This way only specific stacks are updated at a time. Because I didn't want the VPC and Database destroyed and recreated, I had to leave those two in the same stack. Oh well.

There's duplicate lambdas in the new API stack. This is for two reasons:
1. The original API gateway is still up and active, making the transition from current logic to new logic smoother.
2. I now have a versioned endpoint that we can iterate on for the immediate batching change.

The ServerStack can't be deployed until I remove the CNAME record from the `dev.cid.contact` hosted zone. Once that happens, pgAdmin will be unavailable. The transition process for that looks like removing the CNAME record, deploying the ServerStack, and then setting up the new EC2 instance to run pgAdmin.