### PR TITLE
Explicitly deploy autoretrive pods to `dev-ue2a-r5a-2xl` node group

### DIFF
--- a/deploy/manifests/base/deployment.yaml
+++ b/deploy/manifests/base/deployment.yaml
@@ -41,11 +41,6 @@ spec:
             - name: authorization
               mountPath: /data/.autoretrieve/eventrecorderauth
               subPath: eventrecorderauth
-          resources:
-            limits:
-              memory: 32Gi
-            requests:
-              memory: 32Gi
       volumes:
         - name: config
           configMap:

--- a/deploy/manifests/dev/us-east-2/deployment-patch.yaml
+++ b/deploy/manifests/dev/us-east-2/deployment-patch.yaml
@@ -6,11 +6,25 @@ metadata:
 spec:
   template:
     spec:
+      # Deploy autoretrieve nodes explicitly on a node group of type r5a.2xlarge in us-east-2a.
+      # Because, it uses a PVC volume that is currently created in us-east-2a.
+      # This combined with the configured resource limit  makes sure that the worker nodes would 
+      # exclusively run autoretrieve pods, avoid scheduling interference cause by the k8s cluster
+      # autoscaling/binpacking policy to reduce cost when possible.
+      # See: https://github.com/filecoin-project/storetheindex/blob/e5a2bbec268abed470d6211185d074fea4057c2a/deploy/infrastructure/dev/us-east-2/eks.tf#L37
+      nodeSelector:
+        node.kubernetes.io/instance-type: r5a.2xlarge
+        topology.kubernetes.io/zone: us-east-2a
       containers:
         - name: autoretrieve
           volumeMounts:
             - name: cache
               mountPath: /data
+          resources:
+            limits:
+              memory: 60Gi
+            requests:
+              memory: 60Gi
       volumes:
         - name: cache
           persistentVolumeClaim:


### PR DESCRIPTION
The autoretieve deployment was configured to use up to 32Gi of memory. Currently, autoretrieve gets rescheduled because it consumes more memory than it is allowed to every 12 hours or so. The worker node group set up for it however has up to 64Gi memory. This means when autoretrieve is scheduled, there is spare capacity on the worker node to run other pods which could delay the scheduling of autoretrieve when it is restarted.

Considering the memory consumption of autoretrieve, increase the memory limit to 60Gi so that there is more memory available to the pod while leaving 4Gi of spare memory for the other administrative pods that need to run on every node (like log forwarders etc.).

Additionally, explicitly configure node selectors to have a predictable scheduling for autorerive pods on worker node group created for it.

The combination of these two changes mean: autoretrieve will always get scheduled on the AZ where its current PVC is, and because it demands larger memory there will be no spare capacity to run other pods that could delay its startup.

Note, the resouce limit config is moved from `base` overlay to `dev` since it is a dev-specific configuration.