### PR TITLE
add CPU limit so that cpu usage is trackable in grafana.

### DIFF
--- a/deploy/manifests/dev/us-east-2/deployment-patch.yaml
+++ b/deploy/manifests/dev/us-east-2/deployment-patch.yaml
@@ -22,8 +22,10 @@ spec:
               mountPath: /data
           resources:
             limits:
+              cpu: "6"
               memory: 60Gi
             requests:
+              cpu: "6"
               memory: 60Gi
       volumes:
         - name: cache


### PR DESCRIPTION
the r5a.2xlarge that augtoretrieve is deployed on has 8 cores, so setting the limit such that there's some reserve held back for k8s