### PR TITLE
Increase concurrency

### DIFF
--- a/deploy/manifests/dev/us-east-2/config.yaml
+++ b/deploy/manifests/dev/us-east-2/config.yaml
@@ -2,7 +2,7 @@ advertise-endpoint-url: ""
 advertise-token: ""
 lookup-endpoint-type: indexer
 lookup-endpoint-url: https://cid.contact
-max-bitswap-workers: 1
+max-bitswap-workers: 5
 routing-table-type: dht
 prune-threshold: 45 GB
 pin-duration: 1h0m0s
@@ -14,7 +14,7 @@ miner-blacklist: []
 miner-whitelist: []
 default-miner-config:
     retrieval-timeout: 1m0s
-    max-concurrent-retrievals: 1
+    max-concurrent-retrievals: 2
 miner-configs: {}
 event-recorder-endpoint-url: https://cv6xplf91j.execute-api.us-east-2.amazonaws.com/prod/v1/retrieval-events
 instance-name: bedrock-dev


### PR DESCRIPTION
Bumping per-SP retrieval concurrency to 2. I'm also bumping the bitswap worker count, we probably should have done that a while ago (we had the conversation) and since the provider rewrite is on the shelf for the moment let's increase the throughput on that thing.