### PR TITLE
Db proxy

### DIFF
--- a/lassie-event-recorder-api/app/saturn-event-recorder.ts
+++ b/lassie-event-recorder-api/app/saturn-event-recorder.ts
@@ -1,12 +1,11 @@
 #!/usr/bin/env node
 import "source-map-support/register";
-import { App } from "aws-cdk-lib";
+import { App, Duration } from "aws-cdk-lib";
 import { ApiStack } from "../src/infra/stacks/api-stack";
 import { DatabaseStack } from "../src/infra/stacks/database-stack";
 import { DeleteOldEventsStack } from "../src/infra/stacks/delete-old-events-stack";
 import { ServerStack } from "../src/infra/stacks/server-stack";
 import { VpcStack } from "../src/infra/stacks/vpc-stack";
-
 const ACCOUNT_ID = "407967248065";
 const STACK_PROPS = {
   env: {
@@ -23,23 +22,24 @@ const DESCRIPTION_PREFIX = "Saturn Lassie Events"
 
 const app = new App();
 
-const { vpc } = new VpcStack(app,  "VpcStack", {
+const { vpc } = new VpcStack(app, "VpcStack", {
   description: `${DESCRIPTION_PREFIX} | VPC`,
   stackName: `${PREFIX}VpcStack`,
   prefix: PREFIX,
   ...STACK_PROPS
 });
 
-const {database} = new DatabaseStack(app, "DatabaseStack", {
+const { database, proxy } = new DatabaseStack(app, "DatabaseStack", {
   description: `${DESCRIPTION_PREFIX} | Database`,
   stackName: `${PREFIX}DatabaseStack`,
   prefix: PREFIX,
   vpc,
+  proxyBorrowTimeout: Duration.seconds(30),
   ...STACK_PROPS
 });
 
 const databaseEnvironment = {
-  DB_HOST: database.secret.secretValueFromJson("host").toString(),
+  DB_HOST: proxy.endpoint,
   DB_PORT: database.secret.secretValueFromJson("port").toString(),
   // Passing the password via environment variable is not ideal, but it allows us to use connection pools effeciently
   DB_PASSWORD: database.secret.secretValueFromJson("password").toString(),
@@ -51,6 +51,7 @@ new DeleteOldEventsStack(app, "DeleteOldEventsStack", {
   description: `${DESCRIPTION_PREFIX} | Lambda for deleting old events from the database`,
   stackName: `${PREFIX}DeleteOldEventsStack`,
   database,
+  proxy,
   databaseEnvironment,
   prefix: PREFIX,
   interval: "1 week",
@@ -73,6 +74,7 @@ new ApiStack(app, "ApiStack", {
   description: `${DESCRIPTION_PREFIX} | API`,
   stackName: `${PREFIX}ApiStack`,
   database,
+  proxy,
   databaseEnvironment,
   prefix: PREFIX,
   vpc,

--- a/lassie-event-recorder-api/app/saturn-event-recorder.ts
+++ b/lassie-event-recorder-api/app/saturn-event-recorder.ts
@@ -51,7 +51,6 @@ new DeleteOldEventsStack(app, "DeleteOldEventsStack", {
   description: `${DESCRIPTION_PREFIX} | Lambda for deleting old events from the database`,
   stackName: `${PREFIX}DeleteOldEventsStack`,
   database,
-  proxy,
   databaseEnvironment,
   prefix: PREFIX,
   interval: "1 week",

--- a/lassie-event-recorder-api/src/infra/stacks/database-stack.ts
+++ b/lassie-event-recorder-api/src/infra/stacks/database-stack.ts
@@ -31,11 +31,10 @@ export class DatabaseStack extends Stack {
       value: this.database.secret.secretName
     });
 
-    this.proxy = new DatabaseProxy(this, "Proxy", {
+    this.proxy = this.database.database.addProxy(`${props.prefix}-DatabaseProxy`, {
       borrowTimeout: props.proxyBorrowTimeout,
-      dbProxyName: `${props.prefix}-DatabaseProxy`,
-      proxyTarget: ProxyTarget.fromInstance(this.database.database),
       secrets: [this.database.secret],
+      securityGroups: [this.database.securityGroup],
       vpc: props.vpc
     });
   }

--- a/lassie-event-recorder-api/src/infra/stacks/delete-old-events-stack.ts
+++ b/lassie-event-recorder-api/src/infra/stacks/delete-old-events-stack.ts
@@ -5,10 +5,12 @@ import { Code, Function, IFunction, Runtime } from "aws-cdk-lib/aws-lambda";
 import { IRule, Rule, Schedule } from "aws-cdk-lib/aws-events";
 import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 import { CustomDatabase } from "../constructs/custom-database";
+import { DatabaseProxy } from "aws-cdk-lib/aws-rds";
 
 interface DeleteOldEventsStackProps extends StackProps {
   database: CustomDatabase,
-  databaseEnvironment: {[key: string]: string}
+  proxy: DatabaseProxy,
+  databaseEnvironment: { [key: string]: string }
   interval: string
   prefix: string
   vpc: IVpc
@@ -46,7 +48,8 @@ export class DeleteOldEventsStack extends Stack {
     });
 
     // Grant the lambda connection abilities to the database
-    props.database.grantConnectFromLambda(this, this.lambda);
+    props.proxy.grantConnect(this.lambda); // Give lambda permission to connect to db
+    props.database.secret.grantRead(this.lambda); // Give lambda permission to read database secret
 
     // Invoke the lambda every day to remove interval old events
     this.rule = new Rule(this, "DeleteOldEventsRule", {

--- a/lassie-event-recorder-api/src/infra/stacks/delete-old-events-stack.ts
+++ b/lassie-event-recorder-api/src/infra/stacks/delete-old-events-stack.ts
@@ -5,11 +5,9 @@ import { Code, Function, IFunction, Runtime } from "aws-cdk-lib/aws-lambda";
 import { IRule, Rule, Schedule } from "aws-cdk-lib/aws-events";
 import { LambdaFunction } from "aws-cdk-lib/aws-events-targets";
 import { CustomDatabase } from "../constructs/custom-database";
-import { DatabaseProxy } from "aws-cdk-lib/aws-rds";
 
 interface DeleteOldEventsStackProps extends StackProps {
   database: CustomDatabase,
-  proxy: DatabaseProxy,
   databaseEnvironment: { [key: string]: string }
   interval: string
   prefix: string
@@ -48,8 +46,7 @@ export class DeleteOldEventsStack extends Stack {
     });
 
     // Grant the lambda connection abilities to the database
-    props.proxy.grantConnect(this.lambda); // Give lambda permission to connect to db
-    props.database.secret.grantRead(this.lambda); // Give lambda permission to read database secret
+    props.database.grantConnectFromLambda(this, this.lambda);
 
     // Invoke the lambda every day to remove interval old events
     this.rule = new Rule(this, "DeleteOldEventsRule", {


### PR DESCRIPTION
Put a database proxy in front of the database.

What we're doing here is:
- Adding the proxy
- Connecting the lambda's to the proxy instead
- EC2 stays connected to the DB as is
- Granting access from the lambda's to the proxy only (supposedly, this doesn't have the bug that is present when you try to use grantConnect for RDS direct instances)