### PR TITLE
Add monitoring to event recorder

### DIFF
--- a/deploy/manifests/base/lassie-event-recorder/deployment.yaml
+++ b/deploy/manifests/base/lassie-event-recorder/deployment.yaml
@@ -18,6 +18,8 @@ spec:
           ports:
             - name: http
               containerPort: 8080
+            - name: admin
+              containerPort: 7777
           readinessProbe:
             httpGet:
               path: /ready

--- a/deploy/manifests/dev/us-east-2/lassie-event-recorder/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/lassie-event-recorder/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - db-dsn-secret.yaml
   - basic-auth-secret.yaml
   - ingress.yaml
+  - monitor.yaml
 
 patchesStrategicMerge:
   - patch.yaml

--- a/deploy/manifests/dev/us-east-2/lassie-event-recorder/monitor.yaml
+++ b/deploy/manifests/dev/us-east-2/lassie-event-recorder/monitor.yaml
@@ -1,0 +1,16 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: lassie-event-recorder
+  labels:
+    app: lassie-event-recorder
+spec:
+  selector:
+    matchLabels:
+      app: lassie-event-recorder
+  namespaceSelector:
+    matchNames:
+      - autoretrieve
+  podMetricsEndpoints:
+    - path: /metrics
+      port: admin


### PR DESCRIPTION
# Goals

Expose Lassie prometheus monitoring

# Implementation

-- copied file from autoretrieve
-- exposed port on event recorder
-- namespace for pods appears to still be "autoretrieve" so I just used that

-- am I doing this right???