### PR TITLE
Spin down `autoretrieve` to zero replicas

### DIFF
--- a/deploy/manifests/base/autoretrieve/deployment.yaml
+++ b/deploy/manifests/base/autoretrieve/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: autoretrieve
   namespace: autoretrieve
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app: autoretrieve


### PR DESCRIPTION
The service seem to be no longer in use; spin down for now to reduce cost. To be removed entirely by end of the week.