### PR TITLE
Set overridden `autoretrieve` replica count to zero in `dev`

### DIFF
--- a/deploy/manifests/dev/us-east-2/autoretrieve/kustomization.yaml
+++ b/deploy/manifests/dev/us-east-2/autoretrieve/kustomization.yaml
@@ -14,7 +14,7 @@ patchesStrategicMerge:
 
 replicas:
   - name: autoretrieve
-    count: 1
+    count: 0
 
 configMapGenerator:
   - name: autoretrieve-config


### PR DESCRIPTION
Because the overlay overrides the replica count in `dev` the value needs
 to be changed explicitly in the corresponding overlay.